### PR TITLE
管理画面からサマリ画像を追加できるようにする

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -2,6 +2,10 @@
 title: '4月20日(土) '
 subtitle: '総会：12:30-13:10 / 懇親会：13:40-16:00'
 image: /img/main_img7.png
+summary: 
+  title: タイトルテスト
+  imageUrl: /img/products-grid1.jpg
+  imageAlt: alt test
 blurb:
   heading: ”平成最後の同窓会”
   text: >-

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -6,6 +6,8 @@
 
 {{ partial "single-button" .Params.regist }}
 
+{{ partial "single-image" (dict "title" .Params.summary.title "imageUrl" .Params.summary.imageUrl "imageAlt" .Params.summary.imageAlt)}}
+
 {{ partial "google-map" . }}
 
 {{ partial "blog" . }}

--- a/site/layouts/partials/single-image.html
+++ b/site/layouts/partials/single-image.html
@@ -1,8 +1,8 @@
 <div class="bg-off-white pv4">
-  {{ if .title }}
-  <h2 class="f2 b lh-title mb3">{{.title}}</h2>
-  {{ end }}
   <div class="ph3 center mw7">
-    <img src="{{ .imageUrl }}" alt="{{.imageAlt}}" class="center w-100"/>
+    {{ if .title }}
+    <h2 class="f2 b lh-title mb3">{{.title}}</h2>
+    {{ end }}
+    <img src="{{ .imageUrl }}" alt="{{.imageAlt}}" class="center w-100" />
   </div>
 </div>

--- a/site/layouts/partials/single-image.html
+++ b/site/layouts/partials/single-image.html
@@ -1,0 +1,8 @@
+<div class="bg-off-white pv4">
+  {{ if .title }}
+  <h2 class="f2 b lh-title mb3">{{.title}}</h2>
+  {{ end }}
+  <div class="ph3 center mw7">
+    <img src="{{ .imageUrl }}" alt="{{.imageAlt}}" class="center w-100"/>
+  </div>
+</div>

--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -39,6 +39,10 @@ collections: # A list of collections the CMS should be able to edit
           - {label: Title, name: title, widget: string}
           - {label: Subtitle, name: subtitle, widget: string}
           - {label: Image, name: image, widget: image}
+          - {label: "Summary", name: summary, widget: object, fields: [
+              {label: "title", name: "title", widget: string},
+              {label: "image", name: "imageUrl", widget: image}
+              {label: "imageAlt", name: "imageAlt", widget: string}]}
           - {label: "Blurb", name: blurb, widget: object, fields: [
               {label: "Heading", name: "heading", widget: string},
               {label: "Text", name: "text", widget: "text"}]}

--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -39,10 +39,10 @@ collections: # A list of collections the CMS should be able to edit
           - {label: Title, name: title, widget: string}
           - {label: Subtitle, name: subtitle, widget: string}
           - {label: Image, name: image, widget: image}
-          - {label: "Summary", name: summary, widget: object, fields: [
-              {label: "title", name: "title", widget: string},
-              {label: "image", name: "imageUrl", widget: image},
-              {label: "imageAlt", name: "imageAlt", widget: string}]}
+          - {label: Summary, name: summary, widget: object, fields: [
+              {label: Title, name: title, widget: string},
+              {label: image, name: imageUrl, widget: image},
+              {label: imageAlt, name: imageAlt, widget: string}]}
           - {label: "Blurb", name: blurb, widget: object, fields: [
               {label: "Heading", name: "heading", widget: string},
               {label: "Text", name: "text", widget: "text"}]}

--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -41,7 +41,7 @@ collections: # A list of collections the CMS should be able to edit
           - {label: Image, name: image, widget: image}
           - {label: "Summary", name: summary, widget: object, fields: [
               {label: "title", name: "title", widget: string},
-              {label: "image", name: "imageUrl", widget: image}
+              {label: "image", name: "imageUrl", widget: image},
               {label: "imageAlt", name: "imageAlt", widget: string}]}
           - {label: "Blurb", name: blurb, widget: object, fields: [
               {label: "Heading", name: "heading", widget: string},


### PR DESCRIPTION
## 関連Issue
- `fhs46-fujimoto/one-click-hugo-cms#5`
## 概要
```
縦軸：人数
横軸：卒業回
な、棒グラフが、いいな

データは、netlify cms で入力するか、スプレッドシートに入力していってるので、そのデータからグラフをおこして、
画像を netlify cms に画像を張り付ける　でもいい。
今週末くらいから、毎週更新していく感じになるので、あまり手間にならない方法がいいかな
```
## 対応方針
- 管理画面から画像を張り付けられるようにする